### PR TITLE
cursor offset fix

### DIFF
--- a/src/Map.js
+++ b/src/Map.js
@@ -11,7 +11,7 @@ export default class Map extends React.Component {
 		this.state = {
 			map: haven,
 			color: "#ffc600",
-			brushRadius: 4,
+			brushRadius: 3,
 			lazyRadius: 4,
 			canvasWidth: 0,
 			canvasHeight: 0,
@@ -130,6 +130,7 @@ export default class Map extends React.Component {
 					<CanvasDraw
 						ref={canvasDraw => (this.Canvas = canvasDraw)}
 						imgSrc={this.state.map}
+						lazyRadius={this.state.lazyRadius}
 						brushColor={this.state.color}
 						brushRadius={this.state.brushRadius}
 						canvasWidth={this.state.canvasWidth}

--- a/src/canvas/index.js
+++ b/src/canvas/index.js
@@ -67,7 +67,7 @@ export default class extends PureComponent {
   static defaultProps = {
     onChange: null,
     loadTimeOffset: 5,
-    lazyRadius: 3,
+    lazyRadius: 12,
     brushRadius: 10,
     brushColor: "#444",
     catenaryColor: "#0a0302",


### PR DESCRIPTION
The cursor offset was caused by a LazyBrush setting, namely "lazyRadius".

The purpose of the setting was to eliminate ragged edges when drawing lines, originally, the value was set to 12 which caused the offset. After some setting I've reduced it to an acceptable value of 3 to retain the original purpose of the setting while keeping the offset negligible.